### PR TITLE
Fix reset outputs

### DIFF
--- a/__tests__/store.test.ts
+++ b/__tests__/store.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest'
+import { useRoyalCalcStore } from '../lib/store'
+import { calculateProjectedYield } from '../lib/calculator'
+
+const defaultOutputs = calculateProjectedYield(10000, 1, 10)
+
+describe('useRoyalCalcStore reset', () => {
+  it('resets outputs to default values', () => {
+    const store = useRoyalCalcStore.getState()
+    // change state to something else
+    store.setInput('investmentAmountUSD', 5000)
+    expect(useRoyalCalcStore.getState().outputs).not.toEqual(defaultOutputs)
+
+    store.reset()
+
+    expect(useRoyalCalcStore.getState().outputs).toEqual(defaultOutputs)
+  })
+})

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -43,5 +43,13 @@ export const useRoyalCalcStore = create<RoyalCalcState>((set, get) => ({
     }
   },
 
-  reset: () => set({ inputs: defaultInputs }),
+  reset: () =>
+    set({
+      inputs: defaultInputs,
+      outputs: calculateProjectedYield(
+        defaultInputs.investmentAmountUSD,
+        Number(defaultInputs.stakingDurationYears),
+        defaultInputs.projectedAnnualReturnRate
+      ),
+    }),
 })); 


### PR DESCRIPTION
## Summary
- make `reset` also update outputs with default values
- add a unit test for `reset`

## Testing
- `pnpm lint` *(fails: `next` not found)*
- `pnpm test` *(fails: `vitest` not found)*