### PR TITLE
Add form validation with zodResolver

### DIFF
--- a/__tests__/calculatorForm.test.tsx
+++ b/__tests__/calculatorForm.test.tsx
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import CalculatorForm from '../components/core/CalculatorForm'
+
+describe('CalculatorForm validation', () => {
+  it('shows error for negative investment amount', async () => {
+    render(<CalculatorForm />)
+    const amountInput = screen.getByLabelText(/investment amount/i)
+    fireEvent.change(amountInput, { target: { value: '-5' } })
+    fireEvent.click(screen.getByRole('button', { name: /calculate/i }))
+
+    expect(await screen.findByText(/investment must be positive/i)).toBeInTheDocument()
+  })
+})

--- a/components/core/CalculatorForm/index.tsx
+++ b/components/core/CalculatorForm/index.tsx
@@ -2,11 +2,17 @@
 
 import { useRoyalCalcStore } from '@/lib/store';
 import { useForm } from 'react-hook-form';
-import { MainCalculatorInputs } from '@/lib/schemas';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { MainCalculatorInputs, MainCalculatorInputsSchema } from '@/lib/schemas';
 
 export default function CalculatorForm() {
   const { inputs, setInput } = useRoyalCalcStore();
-  const { register, handleSubmit } = useForm<MainCalculatorInputs>({
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<MainCalculatorInputs>({
+    resolver: zodResolver(MainCalculatorInputsSchema),
     defaultValues: {
       investmentAmountUSD: inputs.investmentAmountUSD,
       stakingDurationYears: String(inputs.stakingDurationYears) as any,
@@ -25,19 +31,28 @@ export default function CalculatorForm() {
       <div>
         <label className="block text-sm font-medium mb-1">Investment Amount (USD)</label>
         <input type="number" step="0.01" className="w-full border rounded p-2" {...register('investmentAmountUSD', { valueAsNumber: true })} />
+        {errors.investmentAmountUSD && (
+          <p className="text-red-600 text-sm mt-1">{errors.investmentAmountUSD.message}</p>
+        )}
       </div>
 
       <div>
         <label className="block text-sm font-medium mb-1">Staking Duration (years)</label>
-        <select className="w-full border rounded p-2" {...register('stakingDurationYears')}> 
+        <select className="w-full border rounded p-2" {...register('stakingDurationYears')}>
           <option value="1">1</option>
           <option value="2">2</option>
         </select>
+        {errors.stakingDurationYears && (
+          <p className="text-red-600 text-sm mt-1">{errors.stakingDurationYears.message}</p>
+        )}
       </div>
 
       <div>
         <label className="block text-sm font-medium mb-1">Projected Annual Return Rate (%)</label>
         <input type="number" step="0.01" className="w-full border rounded p-2" {...register('projectedAnnualReturnRate', { valueAsNumber: true })} />
+        {errors.projectedAnnualReturnRate && (
+          <p className="text-red-600 text-sm mt-1">{errors.projectedAnnualReturnRate.message}</p>
+        )}
       </div>
 
       <button type="submit" className="bg-royal-gold text-brand_white px-4 py-2 rounded w-full hover:opacity-90">Calculate</button>

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "react-dom": "18.2.0",
     "zustand": "4.4.1",
     "react-hook-form": "7.48.2",
+    "@hookform/resolvers": "3.3.3",
     "zod": "3.22.4",
     "recharts": "2.8.0"
   },

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    setupFiles: './test/setup.ts',
+  },
+})


### PR DESCRIPTION
## Summary
- install `@hookform/resolvers`
- validate calculator form with `zodResolver`
- display field error messages
- add vitest config for jsdom
- add test covering form validation

## Testing
- `pnpm test` *(fails: vitest not found)*