### PR TITLE
Improve dashboard heading

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,9 +4,9 @@ import ResultsPanel from '@/components/core/ResultsPanel';
 export default function Page() {
   return (
     <div className="max-w-2xl mx-auto">
-      <h1 className="text-3xl font-display mb-4 text-royal-black">RoyalCalc – Yield Projection</h1>
+      <h1 className="text-3xl font-display mb-4 text-royal-black">RoyalCalc Dashboard</h1>
       <CalculatorForm />
       <ResultsPanel />
     </div>
   );
-} 
+}


### PR DESCRIPTION
## Summary
- simplify the landing page heading to say "RoyalCalc Dashboard"

## Testing
- `pnpm lint` *(fails: `next` not found)*
- `pnpm test` *(fails: `vitest` not found)*