### PR TITLE
Add lint step to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Build Docker image
         run: docker build -t repo-dev .
+      - name: Run lint
+        run: docker run --rm repo-dev pnpm lint
       - name: Run setup script
         run: |
           mkdir artifacts

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN corepack enable && corepack prepare pnpm@8.15.4 --activate
 # Pre-install node dependencies
 WORKDIR /app
 COPY package.json pnpm-lock.yaml ./
+ENV NODE_ENV=development
 RUN pnpm install --frozen-lockfile
 
 # Copy source


### PR DESCRIPTION
## Summary
- ensure dev deps get installed in Docker image
- run `pnpm lint` before tests in CI

## Testing
- `pnpm lint` *(fails: next not found)*
- `pnpm test` *(fails: vitest not found)*